### PR TITLE
Store password in OS X keychain

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,11 @@ gem 'fine_ants'
 gem 'slim-rails'
 gem 'administrate'
 gem 'bourbon'
-gem 'dotenv'
+gem 'dotenv' # Is this being used?
 gem 'money-rails'
 gem 'puma'
 gem 'good_migrations'
+gem 'ruby-keychain', :require => 'keychain'
 
 gem 'rails', '4.2.7'
 gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    corefoundation (0.2.0)
+      ffi
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
     debug_inspector (0.0.2)
@@ -162,6 +164,9 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.2.2)
+    ruby-keychain (0.3.2)
+      corefoundation (~> 0.2.0)
+      ffi
     rubyzip (1.2.0)
     sass (3.4.22)
     sass-rails (5.0.6)
@@ -227,6 +232,7 @@ DEPENDENCIES
   pry
   puma
   rails (= 4.2.7)
+  ruby-keychain
   sass-rails (~> 5.0)
   slim-rails
   sqlite3
@@ -235,4 +241,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/models/bank.rb
+++ b/app/models/bank.rb
@@ -1,2 +1,6 @@
 class Bank < ActiveRecord::Base
+  # TODO: This is a temporary hack. Get the server from the adapter.
+  def server
+    'personal.vanguard.com'
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,13 @@
 class User < ActiveRecord::Base
   belongs_to :bank
   has_and_belongs_to_many :accounts
+
+  delegate :password, :password=, to: :user_password
+  delegate :server, to: :bank
+
+  private
+
+  def user_password
+    @user_password ||= UserPassword.new(server: server, account: user)
+  end
 end

--- a/app/models/user_password.rb
+++ b/app/models/user_password.rb
@@ -1,0 +1,49 @@
+class UserPassword
+  PASSWORD_STORE = Keychain.internet_passwords
+
+  def initialize(server:, account:, protocol: Keychain::Protocols::HTTPS)
+    @server = server
+    @account = account
+    @protocol = protocol
+  end
+
+  def password
+    keychain_item.password if keychain_item.present?
+  end
+
+  def password=(password)
+    # There's a race condition here. Not a big deal, probably. But still...
+    # Is there an atomic upsert option for keychain to avoid it? Or a way to
+    # lock the keychain?
+    if keychain_item.present?
+      update_password(password)
+    else
+      insert_password(password)
+    end
+  end
+
+  private
+
+  attr_reader :server, :account, :protocol
+
+  def update_password(password)
+    keychain_item.password = password
+    keychain_item.save!
+  end
+
+  def insert_password(password)
+    PASSWORD_STORE.create(keychain_item_attributes.merge(password: password))
+  end
+
+  def keychain_item
+    @keychain_item ||= PASSWORD_STORE.where(keychain_item_attributes).first
+  end
+
+  def keychain_item_attributes
+    {
+      server: server,
+      protocol: protocol,
+      account: account,
+    }
+  end
+end

--- a/db/migrate/20160807203540_remove_password_from_users.rb
+++ b/db/migrate/20160807203540_remove_password_from_users.rb
@@ -1,0 +1,5 @@
+class RemovePasswordFromUsers < ActiveRecord::Migration
+  def change
+    remove_column :users, :password, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160807140850) do
+ActiveRecord::Schema.define(version: 20160807203540) do
 
   create_table "accounts", force: :cascade do |t|
     t.integer  "bank_id"
@@ -55,7 +55,6 @@ ActiveRecord::Schema.define(version: 20160807140850) do
   create_table "users", force: :cascade do |t|
     t.integer  "bank_id"
     t.string   "user"
-    t.string   "password"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
I like the idea of storing the account/user passwords in the OS X keychain.

Then, if there's a nice way to encrypt the DB -- or at least certain columns - I haven't found a good option yet -- then we could eliminate the encrypted disk image.

And then... using puma-dev, you could just hit http://fine-ants-app.dev/ and the app would spin up and "just work" without any thought of encryption, etc. Which would be cool...

Curious what you think of this approach.
