### PR TITLE
Bump fine_ants gem to 1.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.14)
-    fine_ants (1.0.1)
+    fine_ants (1.3.0)
       capybara (~> 2.7)
       selenium-webdriver (~> 2.53)
     globalid (0.3.7)


### PR DESCRIPTION
Fine_ants is currently locked to 1.0.1, leaving out some of the upgraded adapters and autoloading goodness.